### PR TITLE
Print checklist on its own page with AEA Data Editor header

### DIFF
--- a/_guidance/preparing-replication-package.md
+++ b/_guidance/preparing-replication-package.md
@@ -33,6 +33,11 @@ You can use an AI assistant (such as Claude, ChatGPT, or GitHub Copilot) to guid
 
 The AI will work through each step with you, identify issues, and suggest specific fixes.
 
+<div class="page-break-before print-only print-header">
+  <img src="/images/logo-aea-88x88.jpg" alt="AEA Data Editor logo">
+  <span>Office of the AEA Data Editor</span>
+</div>
+
 ## Checklist
 
 Print off (as PDF or on paper) the following checklist, and tick off each item as you complete it. Provide the completed checklist as part of the replication package.

--- a/_sass/custom-print.scss
+++ b/_sass/custom-print.scss
@@ -1,0 +1,35 @@
+/* ==========================================================================
+   CUSTOM PRINT STYLES (site-specific, kept out of the minimal-mistakes theme
+   so theme updates don't clobber these)
+   ========================================================================== */
+
+.print-only {
+  display: none;
+}
+
+@media print {
+
+  .print-only {
+    display: block !important;
+  }
+
+  .print-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #000;
+
+    img {
+      max-height: 60px;
+      width: auto;
+      margin: 0;
+    }
+
+    span {
+      font-size: 1.25rem;
+      font-weight: bold;
+    }
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,6 +6,7 @@
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
+@import "custom-print"; // site-specific print styles, kept separate from the theme
 
 .greedy-nav {
    font-size: 0.8em;


### PR DESCRIPTION
## Summary
- Adds a print-only header (AEA Data Editor logo + name) that appears at the top of a fresh printed page immediately before the "Checklist" section in `preparing-replication-package.md`, so the checklist prints cleanly on its own page.
- New print styles live in `_sass/custom-print.scss`, imported after the `minimal-mistakes` theme in `assets/css/main.scss`, so they survive theme updates instead of being mixed into the theme's own `_print.scss`.

## Test plan
- [x] Verified the SCSS compiles and the HTML renders correctly by replicating the GHA build (Ruby 3.3.4, `bundle install`, `bundle exec jekyll build`) inside a Docker container matching `ubuntu-latest`'s toolchain — confirmed the compiled CSS contains the `.print-only`/`.print-header` rules and the checklist page's HTML contains the header div in the right place.
- [ ] Manually print/print-preview `_guidance/preparing-replication-package.html` in a browser to confirm the visual page break and header layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)