### PR TITLE
Add Cloudflare Pages PR previews

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: >-
           pages deploy ./_site
-          --project-name=aeadataeditor-preview
+          --project-name=aeamain
           --branch=pr-${{ github.event.pull_request.number }}
     - name: Publish preview link
       if: steps.preview.outcome == 'success'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,10 @@
 # The site is always built - on pushes to main, on pull requests, and on
 # manual runs - and the rendered _site is uploaded as a downloadable
 # workflow artifact. Publishing to gh-pages only happens on pushes to main,
-# or on a manual run with the "publish" option checked.
+# or on a manual run with the "publish" option checked. Pull requests from
+# branches of this repository (not forks) additionally get a live preview
+# deployed to Cloudflare Pages, with the link posted as a PR comment. See
+# README-DEPLOYMENT.md for the one-time Cloudflare setup.
 
 name: Build website
 
@@ -74,3 +77,40 @@ jobs:
          user_email: 'lars.vilhuber@cornell.edu'
          publish_branch: gh-pages
          keep_files: false
+
+  preview:
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write     # only for the PR comment
+    steps:
+    - name: Download site artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: site
+        path: _site
+    - name: Deploy PR preview
+      id: preview
+      # Forked PRs cannot read secrets, and handing a deploy token to
+      # unreviewed code is a bad trade for a preview.
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      uses: cloudflare/wrangler-action@v4
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: >-
+          pages deploy ./_site
+          --project-name=aeadataeditor-preview
+          --branch=pr-${{ github.event.pull_request.number }}
+    - name: Publish preview link
+      if: steps.preview.outcome == 'success'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ github.event.pull_request.number }}
+        URL: ${{ steps.preview.outputs.pages-deployment-alias-url }}
+      run: |
+        echo "📖 Preview: $URL" >> "$GITHUB_STEP_SUMMARY"
+        gh pr comment "$PR" --edit-last --create-if-none \
+          --body "📖 **Preview:** $URL — commit \`${GITHUB_SHA:0:7}\`"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,9 +108,10 @@ jobs:
       if: steps.preview.outcome == 'success'
       env:
         GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
         PR: ${{ github.event.pull_request.number }}
         URL: ${{ steps.preview.outputs.pages-deployment-alias-url }}
       run: |
         echo "📖 Preview: $URL" >> "$GITHUB_STEP_SUMMARY"
-        gh pr comment "$PR" --edit-last --create-if-none \
+        gh pr comment "$PR" --repo "$REPO" --edit-last --create-if-none \
           --body "📖 **Preview:** $URL — commit \`${GITHUB_SHA:0:7}\`"

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -51,14 +51,14 @@ deploy anything.
    ```
 
 4. **Create the Cloudflare Pages project**, if it doesn't already exist.
-   The workflow deploys to a project named `aeadataeditor-preview`
+   The workflow deploys to a project named `aeamain`
    (see the `--project-name` flag in the `preview` job). Create it once with
    [Wrangler](https://developers.cloudflare.com/workers/wrangler/) (requires
    Node.js):
 
    ```bash
    npx wrangler login
-   npx wrangler pages project create aeadataeditor-preview
+   npx wrangler pages project create aeamain
    ```
 
    If you'd rather not install anything locally, you can instead just open a

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -1,0 +1,90 @@
+# Deployment & PR previews
+
+This repo's site is built with Jekyll and published to `gh-pages` via
+[.github/workflows/main.yml](.github/workflows/main.yml). That workflow has
+three jobs:
+
+- **build** — always runs (push to `main`, pull requests, manual dispatch).
+  Builds the Jekyll site and uploads it as a workflow artifact named `site`.
+- **publish** — runs on pushes to `main` (or a manual dispatch with
+  "publish" checked). Downloads the `site` artifact and pushes it to the
+  `gh-pages` branch, which serves the live site.
+- **preview** — runs on pull requests opened from a branch of this
+  repository (not a fork). Downloads the `site` artifact and deploys it to
+  [Cloudflare Pages](https://pages.cloudflare.com/) as a per-PR preview,
+  then posts (or updates) a comment on the PR with the preview link.
+
+Forked PRs never run the `preview` job's deploy step, since forks don't have
+access to repository secrets — that's a GitHub Actions security boundary,
+not a bug.
+
+## One-time Cloudflare Pages setup
+
+You need a Cloudflare account and an API token before the `preview` job can
+deploy anything.
+
+1. **Create the Cloudflare API token.**
+   In the Cloudflare dashboard: **My Profile → API Tokens → Create Token**,
+   using the **"Edit Cloudflare Workers"** template (or a custom token with
+   `Account.Cloudflare Pages: Edit` permission). Copy the token value — it's
+   only shown once.
+
+2. **Find your Cloudflare Account ID.**
+   It's shown on the right-hand sidebar of any zone/domain overview page in
+   the Cloudflare dashboard, or via `wrangler whoami` if you have Wrangler
+   installed locally.
+
+3. **Set both as GitHub Actions secrets on this repo**, using the `gh` CLI
+   (run from the repo root, or add `--repo AEADataEditor/aeadataeditor.github.io`
+   from elsewhere):
+
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN --body "<paste the API token>"
+   gh secret set CLOUDFLARE_ACCOUNT_ID --body "<paste the account ID>"
+   ```
+
+   Or omit `--body` to be prompted / pipe the value in:
+
+   ```bash
+   gh secret set CLOUDFLARE_API_TOKEN
+   echo -n "<account id>" | gh secret set CLOUDFLARE_ACCOUNT_ID
+   ```
+
+4. **Create the Cloudflare Pages project**, if it doesn't already exist.
+   The workflow deploys to a project named `aeadataeditor-preview`
+   (see the `--project-name` flag in the `preview` job). Create it once with
+   [Wrangler](https://developers.cloudflare.com/workers/wrangler/) (requires
+   Node.js):
+
+   ```bash
+   npx wrangler login
+   npx wrangler pages project create aeadataeditor-preview
+   ```
+
+   If you'd rather not install anything locally, you can instead just open a
+   PR — `wrangler pages deploy` in CI will create the project automatically
+   on first run if it doesn't exist yet.
+
+5. **Verify the secrets are set:**
+
+   ```bash
+   gh secret list
+   ```
+
+   You should see `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` listed
+   (values are never shown, only names and update times).
+
+## After setup
+
+Once the secrets exist, every PR from a repo branch (not a fork) will get:
+
+- A live preview at a Cloudflare Pages URL specific to that PR
+  (`--branch=pr-<PR number>`), rebuilt on every push to the PR.
+- A PR comment with the preview link, edited in place on each new commit
+  rather than re-posted.
+
+## Changing the project name
+
+If you rename the Cloudflare Pages project, update `--project-name` in the
+`preview` job of [.github/workflows/main.yml](.github/workflows/main.yml) to
+match.


### PR DESCRIPTION
## Summary
- Adds a `preview` job to `.github/workflows/main.yml` that reuses the `site` artifact from `build` and deploys it to Cloudflare Pages for same-repo pull requests (skipped for forks, since they can't read deploy secrets), then posts/updates a PR comment with the preview link.
- Adds `README-DEPLOYMENT.md` documenting the one-time Cloudflare setup, including the `gh secret set CLOUDFLARE_API_TOKEN` / `gh secret set CLOUDFLARE_ACCOUNT_ID` commands and how to create the Cloudflare Pages project.

## Requires (not part of this PR)
- `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets — see README-DEPLOYMENT.md for exact `gh` commands.
- A Cloudflare Pages project named `aeadataeditor-preview` (Wrangler will auto-create it on first deploy if it doesn't exist).

## Test plan
- [x] Validated the workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Once secrets are set, confirm this PR itself (or a follow-up PR) gets a Cloudflare preview comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)