### PR TITLE
Hide second-level checklist items when printing

### DIFF
--- a/_sass/custom-print.scss
+++ b/_sass/custom-print.scss
@@ -39,4 +39,10 @@
   .checklist-list ul {
     page-break-inside: auto;
   }
+
+  // Second-level items (e.g. the Step 3 sub-bullets) are on-screen detail
+  // only and shouldn't print.
+  .checklist-list ul ul {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- The Step 3 sub-bullets ("For Stata", "For R", "For Python") are nested `<ul>`s inside `.checklist-list`. Added `.checklist-list ul ul { display: none; }` in `_sass/custom-print.scss`, scoped to `@media print`, so they're hidden only when printing/PDF-exporting — still visible on screen.

## Test plan
- [x] Rebuilt with `bundle exec jekyll build` in a `ruby:3.3.4` container and confirmed the compiled CSS contains `.checklist-list ul ul{display:none}`, and confirmed the nested `<ul>` under Step 3 in the rendered HTML matches that selector.
- [ ] Print-preview the checklist page to confirm the sub-bullets no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)